### PR TITLE
[webpack-bundle-hash] adds hash to bundle for simple cache-busting

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,6 +53,7 @@ module.exports = {
   plugins: [
     new HtmlWebpackPlugin({
       filename: 'index.html',
+      hash: true,
       template: './index.html',
       env: env,
     }),


### PR DESCRIPTION
e.g. `<script type="text/javascript" src="bundle.js?6380131fbc66ffb2fe5f"></script>`