### PR TITLE
[full-width-wrap] full width for search area

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -23,6 +23,8 @@ body {
   overflow-y: scroll;
 }
 
+.search-area { position: relative; }
+
 .search-wrap-flex {
   display: flex;
   align-items: baseline;
@@ -49,9 +51,16 @@ body {
 /* @media laptops and up */
 @media screen
   and (min-width: 1200px) {
-    .box-content {
-      max-width: 45%;
-      width: 45%;
+    /* content pages go smaller for readability*/
+    .box-content > div {
+      max-width: 800px;
+      width: 800px;
+    }
+
+    /* search stays wide */
+    .box-content .search-area {
+      max-width: 100%;
+      width: 100%;
     }
 }
 /* @media laptops and down */

--- a/src/js/components/Search.jsx
+++ b/src/js/components/Search.jsx
@@ -53,7 +53,7 @@ export class Search extends PureComponent {
 
   render(props) {
     return (
-      <div style={{ position: 'relative' }}>
+      <div className="search-area">
         <SearchBar
           className="search-bar"
           onSearchChange={(data, searchTerm) => (


### PR DESCRIPTION
Resolves #37 

* makes search area 100% (can make search *bar* less than that, if necessary cc: @craigdrown) Looks, OK, though.
* content area stops at 800px on large screens for line readability 