### PR TITLE
[issue-73] loads header quicker than other components

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,8 +13,23 @@
     <meta name="theme-color" content="#ffffff">
 
     <title>Universal Drug Codes</title>
+
+    <style>
+      html,
+      body {
+        margin:0;
+        padding:0;
+        min-height: 100%;
+        height: 100%;
+      }
+      .header svg {
+        fill: #EEE !important;
+      }
+    </style>
   </head>
   <body>
-    <div id="root" class="container"></div>
+    <div id="root" class="container">
+      <div class="header" style="color: rgba(0, 0, 0, 0.87); background-color: rgb(255, 255, 255); transition: all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms; box-sizing: border-box; font-family: Roboto, sans-serif; -webkit-tap-highlight-color: rgba(0, 0, 0, 0); box-shadow: rgba(0, 0, 0, 0.12) 0px 1px 6px, rgba(0, 0, 0, 0.12) 0px 1px 4px; border-radius: 0px; position: relative; z-index: 1100; width: 100%; display: flex; padding-left: 24px; padding-right: 24px; border-bottom: 2px solid rgba(242, 101, 50, 0.55);"><button tabindex="0" type="button" style="border: 10px; box-sizing: border-box; display: inline-block; font-family: Roboto, sans-serif; -webkit-tap-highlight-color: rgba(0, 0, 0, 0); cursor: pointer; text-decoration: none; margin: 8px 8px 0px -16px; padding: 12px; outline: none; font-size: 0px; font-weight: inherit; position: relative; overflow: visible; transition: all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms; width: 48px; height: 48px; background: none;"><div><svg viewBox="0 0 24 24" style="display: inline-block; color: rgb(255, 255, 255); fill: rgb(255, 255, 255); height: 24px; width: 24px; user-select: none; transition: all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms;"><path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"></path></svg></div></button><h1 style="white-space: nowrap; overflow: hidden; text-overflow: ellipsis; margin: 0px; padding-top: 0px; letter-spacing: 0px; font-size: 24px; font-weight: 400; color: rgb(242, 101, 50); height: 64px; line-height: 64px; flex: 1 1 0%;">Universal Drug Codes</h1></div>
+    </div>
   </body>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,7 +52,7 @@ module.exports = {
   output: {
     chunkFilename: '[name].js',
     path: path.join(__dirname, '/build'),
-    filename: 'bundle.js',
+    filename: '[name].js',
   },
   plugins: [
     new CommonsChunkPlugin({


### PR DESCRIPTION
Loads `Header` faster than other components by placing the static markup inside the `index.html`.

React, when loaded, deletes the markup and replaces it with the `Header` component.

This is one way to make the app appear to load faster on slow/spotty connections. With our current Apache server setup it would be difficult to use `ReactDOMServer.renderToString()` because there is no `node`.

This is one way to cheat a little bit. The only downside, is that if we ever re-design the `Header` we must remember to update the markup (though it should be readily apparent on dev builds!).
